### PR TITLE
Allow building outside of Qubes OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,7 @@ name = "notification-proxy-server"
 
 [[bin]]
 name = "notification-proxy-client"
+
+[features]
+unicode = []
+default = ["unicode"]


### PR DESCRIPTION
To do so, disable the "unicode" feature.  This limits notifications to ASCII-only.