### PR TITLE
Readability improvements

### DIFF
--- a/src/bin/notification-proxy-client.rs
+++ b/src/bin/notification-proxy-client.rs
@@ -156,20 +156,20 @@ impl Server {
                     })
                 }
                 "sound-file" => {
-                    eprintln!("Not yet implemented: Sound files (got {j})")
+                    eprintln!("Not yet implemented: Sound files (got {j:?})")
                 }
                 "sound-name" => {
-                    eprintln!("Not yet implemented: Sound files specified by name (got {j})")
+                    eprintln!("Not yet implemented: Sound files specified by name (got {j:?})")
                 }
                 "suppress-sound" => suppress_sound = true,
                 "transient" => transient = true,
                 "resident" => resident = true,
-                "x" | "y" => eprintln!("Ignoring coordinate hint {i} {j}"),
+                "x" | "y" => eprintln!("Ignoring coordinate hint {i} {j:?}"),
                 "urgency" => match j {
                     Value::U8(0) => urgency = Some(Urgency::Low),
                     Value::U8(1) => urgency = Some(Urgency::Normal),
                     Value::U8(2) => urgency = Some(Urgency::Critical),
-                    _ => eprintln!("Ignoring unknown urgency value {j}"),
+                    _ => eprintln!("Ignoring unknown urgency value {j:?}"),
                 },
                 _ => {
                     eprintln!("Unknown hint {i}, ignoring");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ extern "C" {
 /// - Text is truncated after 500 lines.
 ///
 /// Too many lines in particular is known to make xfce4-notifyd spin and consume 100% CPU.
-pub fn sanitize_str(arg: String) -> String {
+pub fn sanitize_string(arg: String) -> String {
     let mut res = String::with_capacity(arg.len());
     let mut iter = arg.chars().peekable();
     let mut counter = 0;
@@ -521,7 +521,7 @@ impl NotificationEmitter {
                     // Sanitized by is_valid_action_name()
                     actions.push(s)
                 } else {
-                    actions.push(sanitize_str(s))
+                    actions.push(sanitize_string(s))
                 }
             }
             actions
@@ -586,7 +586,7 @@ impl NotificationEmitter {
         }
         let mut escaped_body;
         if self.body_markup() {
-            let body = sanitize_str(untrusted_body);
+            let body = sanitize_string(untrusted_body);
             // Body markup must be escaped.  FIXME: validate it instead.
             escaped_body = String::with_capacity(body.as_bytes().len());
             // this is slow and can easily be made much faster with
@@ -604,7 +604,7 @@ impl NotificationEmitter {
                 }
             }
         } else {
-            escaped_body = sanitize_str(untrusted_body)
+            escaped_body = sanitize_string(untrusted_body)
         }
         let host_id_num = match host_id {
             None => 0,
@@ -616,7 +616,7 @@ impl NotificationEmitter {
                     application_name,
                     host_id_num,
                     icon,
-                    &*(self.prefix.clone() + &*sanitize_str(untrusted_summary)),
+                    &*(self.prefix.clone() + &*sanitize_string(untrusted_summary)),
                     &*escaped_body,
                     &*actions,
                     &hints,
@@ -684,12 +684,12 @@ mod tests {
         // The underlying C library has extensive tests,
         // including a test that it is memory safe on all possible
         // inputs.  Only do minimal tests here.
-        assert_eq!(sanitize_str("&".to_string()), "&".to_string());
-        assert_eq!(sanitize_str("\n".to_string()), "\n".to_string());
-        assert_eq!(sanitize_str("\t".to_string()), "\t".to_string());
+        assert_eq!(sanitize_string("&".to_string()), "&".to_string());
+        assert_eq!(sanitize_string("\n".to_string()), "\n".to_string());
+        assert_eq!(sanitize_string("\t".to_string()), "\t".to_string());
         // \x15 isn't safe
         assert_eq!(
-            sanitize_str("a\x15\n".to_string()),
+            sanitize_string("a\x15\n".to_string()),
             "a\u{FFFD}\n".to_string()
         );
     }
@@ -698,12 +698,12 @@ mod tests {
     fn test_too_many_lines() {
         let max_lines = str::repeat("a\n", 500);
         assert_eq!(
-            &sanitize_str(max_lines.clone()),
+            &sanitize_string(max_lines.clone()),
             &max_lines,
             "500 lines are fine"
         );
         assert_eq!(
-            sanitize_str(max_lines.clone() + &"a\n"[..]),
+            sanitize_string(max_lines.clone() + &"a\n"[..]),
             max_lines,
             "501 lines are not"
         );
@@ -712,7 +712,7 @@ mod tests {
     #[test]
     fn test_too_long_lines() {
         let really_really_long = str::repeat("a", MAX_LINES * MAX_CHARS_PER_LINE);
-        let long_sanitized = sanitize_str(really_really_long);
+        let long_sanitized = sanitize_string(really_really_long);
         assert_eq!(long_sanitized.len(), (MAX_CHARS_PER_LINE + 1) * MAX_LINES);
         let cmp = vec![str::repeat("a", MAX_CHARS_PER_LINE); MAX_LINES].join("\n") + "\n";
         assert_eq!(long_sanitized.len(), cmp.len());
@@ -722,7 +722,7 @@ mod tests {
     #[test]
     fn test_gigunda() {
         let really_really_long = str::repeat("a", MAX_LINES * 2 * MAX_CHARS_PER_LINE);
-        let long_sanitized = sanitize_str(really_really_long);
+        let long_sanitized = sanitize_string(really_really_long);
         assert_eq!(long_sanitized.len(), (MAX_CHARS_PER_LINE + 1) * MAX_LINES);
         let cmp = vec![str::repeat("a", MAX_CHARS_PER_LINE); MAX_LINES].join("\n") + "\n";
         assert_eq!(long_sanitized.len(), cmp.len());

--- a/src/maps.rs
+++ b/src/maps.rs
@@ -1,4 +1,5 @@
 use core::num::NonZeroU32;
+use std::collections::BTreeMap;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
@@ -32,8 +33,8 @@ impl From<HostId> for u32 {
 }
 
 pub(super) struct Maps {
-    guest_to_host_map: std::collections::BTreeMap<NonZeroU32, NonZeroU32>,
-    host_to_guest_map: std::collections::BTreeMap<NonZeroU32, NonZeroU32>,
+    guest_to_host_map: BTreeMap<NonZeroU32, NonZeroU32>,
+    host_to_guest_map: BTreeMap<NonZeroU32, NonZeroU32>,
     last_id: NonZeroU32,
 }
 
@@ -68,7 +69,7 @@ impl Maps {
             self.last_id = next(self.last_id);
         }
         let last_id = self.last_id;
-        eprintln!("Next ID is {}, mapping to host ID {}", last_id, id.0);
+        eprintln!("Next ID is {last_id}, mapping to host ID {}", id.0);
         assert!(self
             .guest_to_host_map
             .insert(last_id, id.0.into())


### PR DESCRIPTION
See #3 for more discussion

This PR doesn't attempt to modify the logic of the program whatsoever, so it should "just work" as it is, but I wasn't able to do any integration tests on it because I don't know how to for now
on
- Use format!() macro to build Strings to prevent appending String + &str
- Some print statements could be simplified by moving the variables into the string literal. This only works for types who implement `Display` though, so it can't be done everywhere. `{foo:?}` works for `Debug` types though, so some extra simplification could be done
- Mainly avoid using "&*" on String/str
- Consume iterators where possible
- Use a `const` value for the Dbus interface name/path where possible