### PR TITLE
Update to zbus 5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include:
-- file: /r4.2/gitlab-base.yml
+- file: /r4.3/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
-- file: /r4.2/gitlab-host.yml
+- file: /r4.3/gitlab-host.yml
   project: QubesOS/qubes-continuous-integration
-- file: /r4.2/gitlab-vm.yml
+- file: /r4.3/gitlab-vm.yml
   project: QubesOS/qubes-continuous-integration

--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -21,3 +21,7 @@ vm-bullseye:
 vm-jammy:
   deb:
     build: []
+
+vm-noble:
+  deb:
+    build: []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ Notification proxy for Qubes OS
 
 [dependencies]
 bincode = "1.3.3"
-bitflags = { version = "1.3.2", default-features = false }
+bitflags = { version = ">=1.3.2", default-features = false }
 futures-channel = "0.3.28"
 futures-util = { version = "0.3.28", default-features = false }
 serde = "1.0.185"
 serde_derive = "1.0.185"
 tokio = { version = "1.29.1", features = ["io-std", "rt", "macros"], default-features = false }
 zbus = { version = "5", features = ["tokio"], default-features = false }
-nix = { version = "0.26.2", features = ["user"], default-features = false }
+nix = { version = ">=0.26.2, <0.30.0", features = ["user"], default-features = false }
 
 [[bin]]
 name = "notification-proxy-server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures-util = { version = "0.3.28", default-features = false }
 serde = "1.0.185"
 serde_derive = "1.0.185"
 tokio = { version = "1.29.1", features = ["io-std", "rt", "macros"], default-features = false }
-zbus = { version = "3.14.1", features = ["tokio"], default-features = false }
+zbus = { version = "5", features = ["tokio"], default-features = false }
 nix = { version = "0.26.2", features = ["user"], default-features = false }
 
 [[bin]]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-notification-proxy (1.0.1-1) unstable; urgency=medium
+qubes-notification (1.0.1-1) unstable; urgency=medium
 
   * Fix .qubesbuilder file for debian
   * spec: add missing dist suffix
@@ -7,14 +7,14 @@ notification-proxy (1.0.1-1) unstable; urgency=medium
 
  -- Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>  Thu, 04 Apr 2024 05:47:11 +0200
 
-notification-proxy (1.0.0-1) unstable; urgency=medium
+qubes-notification (1.0.0-1) unstable; urgency=medium
 
   [ Demi Marie Obenour ]
   * 
 
  -- Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>  Wed, 27 Mar 2024 21:28:42 +0100
 
-notification-proxy (0.1.0-1) unstable; urgency=medium
+qubes-notification (0.1.0-1) unstable; urgency=medium
 
   * Initial release.
 

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: notification-proxy
+Source: qubes-notification
 Section: admin
 Priority: optional
 Maintainer: Demi Marie Obenour <demi@invisiblethingslab.com>
@@ -15,14 +15,14 @@ Build-Depends: debhelper (>= 12),
  librust-serde-dev (>= 1.0.185),
  librust-serde-derive-dev (>= 1.0.185),
  librust-tokio-dev (>= 1.29.1),
- librust-zbus-dev (>= 3.14.1),
+ librust-zbus-dev (>= 5.0.0),
  libqubes-pure-dev,
 Standards-Version: 4.6.1
 Vcs-Git: https://github.com/QubesOS/qubes-notification-proxy.git
 Vcs-Browser: https://github.com/QubesOS/qubes-notification-proxy
 Rules-Requires-Root: no
 
-Package: notification-proxy
+Package: qubes-notification-agent
 Architecture: any
 Multi-Arch: allowed
 Section: admin
@@ -37,4 +37,21 @@ Suggests:
 Provides:
  ${cargo:Provides},
 Built-Using: ${cargo:Built-Using}
-Description: Notification proxy for Qubes OS
+Description: Notification proxy for Qubes OS - agent
+
+Package: qubes-notification-daemon
+Architecture: any
+Multi-Arch: allowed
+Section: admin
+Depends:
+ ${misc:Depends},
+ ${shlibs:Depends},
+ ${cargo:Depends},
+Recommends:
+ ${cargo:Recommends},
+Suggests:
+ ${cargo:Suggests},
+Provides:
+ ${cargo:Provides},
+Built-Using: ${cargo:Built-Using}
+Description: Notification proxy for Qubes OS - daemon

--- a/debian/qubes-notification-agent.install
+++ b/debian/qubes-notification-agent.install
@@ -1,0 +1,3 @@
+/usr/bin/qubes-notification-proxy-client
+/usr/lib/systemd/user/qubes-notification-agent.service
+/usr/lib/systemd/user-preset/90-qubes-notification-agent.preset

--- a/debian/qubes-notification-daemon.install
+++ b/debian/qubes-notification-daemon.install
@@ -1,0 +1,2 @@
+/usr/bin/qubes-notification-proxy-server
+/etc/qubes-rpc/qubes.Notifications

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 include /usr/share/dpkg/architecture.mk
 
-DESTDIR=debian/notification-proxy
+export DESTDIR=debian/tmp
 SYSTEMDUSERDIR=/usr/lib/systemd/user
 
 %:
@@ -12,6 +12,13 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 	dh_auto_install --destdir=$(DESTDIR) -O--buildsystem=cargo
+	mv "$(DESTDIR)/usr/bin/notification-proxy-client" \
+	   "$(DESTDIR)/usr/bin/qubes-notification-proxy-client"
+	mv "$(DESTDIR)/usr/bin/notification-proxy-server" \
+	   "$(DESTDIR)/usr/bin/qubes-notification-proxy-server"
+	# dh-cargo defines substvars only to one subpackage, fix it
+	cp debian/qubes-notification-daemon.substvars \
+		debian/qubes-notification-agent.substvars
 	install -d -- "$(DESTDIR)/etc/qubes-rpc/" "$(DESTDIR)$(SYSTEMDUSERDIR)" "$(DESTDIR)$(SYSTEMDUSERDIR)-preset"
 	install -m0644 -- src/qubes-notification-agent.service "$(DESTDIR)$(SYSTEMDUSERDIR)"
 	install -m0644 -- src/90-qubes-notification-agent.preset "$(DESTDIR)$(SYSTEMDUSERDIR)-preset"

--- a/rust-notification-emitter.spec.in
+++ b/rust-notification-emitter.spec.in
@@ -3,6 +3,12 @@
 
 %global crate notification-emitter
 
+# automatic debuginfo packages do not deal well with subpackages:
+# each subpackage (like -agent-debuginfo) gets dependency on the main debuginfo
+# package, which isn't created
+%global debug_package %{nil}
+
+
 Name:           qubes-notification
 Version:        @VERSION@
 Release:        1%{?dist}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ pub fn sanitize_str(arg: &str) -> String {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct Capabilities: u16 {
         const BODY            = 0b00000000001;
         const BODY_HYPERLINKS = 0b00000000010;
@@ -364,7 +364,7 @@ pub struct NotificationEmitter {
 
 impl NotificationEmitter {
     pub fn capabilities(&self) -> Capabilities {
-        self.capabilities
+        self.capabilities.clone()
     }
     pub async fn new(
         prefix: String,


### PR DESCRIPTION
It's available in F41 (for dom0) already, and in Debian 13 too. Debian
12 wasn't supported with the older version either, so not a regression.

Fixes QubesOS/qubes-issues#10107