### PR TITLE
Allow colon in action name

### DIFF
--- a/src/bin/notification-proxy-client.rs
+++ b/src/bin/notification-proxy-client.rs
@@ -58,7 +58,7 @@ fn is_valid_action_name(action: &[u8]) -> zbus::fdo::Result<()> {
     }
     for (count, i) in action[1..].iter().enumerate() {
         match i {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'.' | b'_' => {}
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b':' => {}
             _ => log_return!(
                 "Action {:?} has a forbidden byte {:?} at position {}.  Please report this.",
                 action,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ fn is_valid_action_name(action: &[u8]) -> bool {
     }
     for i in &action[1..] {
         match i {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'.' | b'_' => {}
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b':' => {}
             _ => return false,
         }
     }

--- a/src/qubes-notification-agent.service
+++ b/src/qubes-notification-agent.service
@@ -6,6 +6,9 @@ ConditionGroup=qubes
 [Service]
 ExecStart=/usr/bin/qrexec-client-vm '' qubes.Notifications /usr/bin/qubes-notification-proxy-client
 BusName=org.freedesktop.Notifications
+RestartSec=1s
+Restart=always
+RestartPreventExitStatus=126 127
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
The spec doesn't say what are allowed characters in the action name, but 
colon is clearly used by some applications, and should be safe to allow.

Fixes QubesOS/qubes-issues#10133

And also set automatic restart, so it reconnects on GUI sessionr restart.