### PR TITLE
Slow down qubes-notification-agent.service restart

### DIFF
--- a/src/bin/notification-proxy-server.rs
+++ b/src/bin/notification-proxy-server.rs
@@ -17,7 +17,7 @@ async fn client_server(qube_name: String) {
     };
     let (emitter, mut server_name_owner_changed) = NotificationEmitter::new(
         qube_name.to_owned() + ": ",
-        "Qubes VM ".to_owned() + &*qube_name,
+        "Qube: ".to_owned() + &*qube_name,
         default_icon,
     )
     .await

--- a/src/qubes-notification-agent.service
+++ b/src/qubes-notification-agent.service
@@ -7,6 +7,8 @@ ConditionGroup=qubes
 ExecStart=/usr/bin/qrexec-client-vm '' qubes.Notifications /usr/bin/qubes-notification-proxy-client
 BusName=org.freedesktop.Notifications
 RestartSec=1s
+RestartMaxDelaySec=30s
+RestartSteps=10
 Restart=always
 RestartPreventExitStatus=126 127
 


### PR DESCRIPTION
When user is not logged into dom0 (or GUI domain) yet, slow down restart to
avoid hitting restart limit, but still eventually connect to the service.

This is not ideal solution to the problem, but an acceptable workaround, 
with less risks of hitting some corner case. See linked issue for more 
details.

Fixes QubesOS/qubes-issues#10137

And also adjust application name - it's displayed in KDE