### PR TITLE
Wait for GUI session on the server side

### DIFF
--- a/debian/qubes-notification-daemon.install
+++ b/debian/qubes-notification-daemon.install
@@ -1,2 +1,3 @@
 /usr/bin/qubes-notification-proxy-server
 /etc/qubes-rpc/qubes.Notifications
+/etc/qubes/rpc-config/qubes.Notifications

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,8 @@ override_dh_auto_install:
 	cp debian/qubes-notification-daemon.substvars \
 		debian/qubes-notification-agent.substvars
 	install -d -- "$(DESTDIR)/etc/qubes-rpc/" "$(DESTDIR)$(SYSTEMDUSERDIR)" "$(DESTDIR)$(SYSTEMDUSERDIR)-preset"
+	install -d -- "$(DESTDIR)/etc/qubes/rpc-config"
 	install -m0644 -- src/qubes-notification-agent.service "$(DESTDIR)$(SYSTEMDUSERDIR)"
 	install -m0644 -- src/90-qubes-notification-agent.preset "$(DESTDIR)$(SYSTEMDUSERDIR)-preset"
 	ln -s -- ../../usr/bin/qubes-notification-proxy-server "$(DESTDIR)/etc/qubes-rpc/qubes.Notifications"
+	echo "wait-for-session=1" > "$(DESTDIR)/etc/qubes/rpc-config/qubes.Notifications"

--- a/rust-notification-emitter.spec.in
+++ b/rust-notification-emitter.spec.in
@@ -74,6 +74,7 @@ forwards notifications to the host's notification daemon.
 %files daemon
 %{_bindir}/qubes-notification-proxy-server
 /etc/qubes-rpc/qubes.Notifications
+/etc/qubes/rpc-config/qubes.Notifications
 
 %package        license
 Summary:        License files for the notification proxy
@@ -99,11 +100,13 @@ License files for the notification proxy
 
 %install
 install -d -- "$RPM_BUILD_ROOT/etc/qubes-rpc/" "$RPM_BUILD_ROOT/%_userunitdir" "$RPM_BUILD_ROOT/%_userpresetdir"
+install -d -- "$RPM_BUILD_ROOT/etc/qubes/rpc-config"
 install -m0644 -- src/qubes-notification-agent.service "$RPM_BUILD_ROOT/%_userunitdir"
 install -m0644 -- src/90-qubes-notification-agent.preset "$RPM_BUILD_ROOT/%_userpresetdir"
 install -D -- target/release/notification-proxy-client "$RPM_BUILD_ROOT/%_bindir/qubes-notification-proxy-client"
 install -D -- target/release/notification-proxy-server "$RPM_BUILD_ROOT/%_bindir/qubes-notification-proxy-server"
 ln -s -- ../../usr/bin/qubes-notification-proxy-server "$RPM_BUILD_ROOT/etc/qubes-rpc/qubes.Notifications"
+echo "wait-for-session=1" > "$RPM_BUILD_ROOT/etc/qubes/rpc-config/qubes.Notifications"
 install -m0644 -D -- LICENSE.dependencies "$RPM_BUILD_ROOT/usr/share/licenses/qubes-notification-proxy/LICENSE.dependencies"
 
 %if %{with check}


### PR DESCRIPTION
For VMs started before user logs in, notification server is not running
at the VM session startup time yet. Instead of failing to start, wait
for the session to become available.

Second attempt.