### PR TITLE
Stub CloseNotification method

### DIFF
--- a/src/bin/notification-proxy-client.rs
+++ b/src/bin/notification-proxy-client.rs
@@ -75,6 +75,10 @@ impl Server {
     async fn get_capabilities(&self) -> zbus::fdo::Result<(Vec<String>,)> {
         Ok((vec!["persistence".to_owned(), "actions".to_owned(), "body".to_owned()],))
     }
+    async fn close_notification(&self, _id: u32) -> zbus::fdo::Result<()> {
+        // FIXME proxy to server (which will proxy back NotificationClosed)
+        Ok(())
+    }
     #[zbus(signal)]
     async fn notification_closed(
         &self,


### PR DESCRIPTION
Required by spec: https://specifications.freedesktop.org/notification/latest-single/#command-close-notification

Test:
```
$ dbus-send --print-reply --dest=org.freedesktop.Notifications /org/freedesktop/Notifications org.freedesktop.Notifications.CloseNotification uint32:1
method return time=1777908540.299342 sender=:1.123 -> destination=:1.136 serial=123 reply_serial=2
```

In blueman, calling `BluezAgent._close()` no longer raises `GDBus.Error`. So this should address the inability to connect devices in some situations from https://github.com/QubesOS/qubes-issues/issues/10862 (there should now be 6 notifications, which is better than 0). I propose resolving that issue but would like someone else to make that decision.