### PR TITLE
debian forky

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = "1.0.185"
 serde_derive = "1.0.185"
 tokio = { version = "1.29.1", features = ["io-std", "rt", "macros"], default-features = false }
 zbus = { version = "5", features = ["tokio"], default-features = false }
-nix = { version = ">=0.26.2, <0.30.0", features = ["user"], default-features = false }
+nix = { version = ">=0.26.2, <0.32.0", features = ["user"], default-features = false }
 
 [[bin]]
 name = "notification-proxy-server"

--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,13 @@ override_dh_auto_install:
 	mv "$(DESTDIR)/usr/bin/notification-proxy-server" \
 	   "$(DESTDIR)/usr/bin/qubes-notification-proxy-server"
 	# dh-cargo defines substvars only to one subpackage, fix it
+	if ! [ -e debian/qubes-notification-agent.substvars ]; then \
+	    cp debian/qubes-notification-daemon.substvars \
+	        debian/qubes-notification-agent.substvars; \
+	elif ! [ -e debian/qubes-notification-daemon.substvars ]; then \
+	    cp debian/qubes-notification-agent.substvars \
+	        debian/qubes-notification-daemon.substvars; \
+	fi
 	cp debian/qubes-notification-daemon.substvars \
 		debian/qubes-notification-agent.substvars
 	install -d -- "$(DESTDIR)/etc/qubes-rpc/" "$(DESTDIR)$(SYSTEMDUSERDIR)" "$(DESTDIR)$(SYSTEMDUSERDIR)-preset"


### PR DESCRIPTION
- **Bump required nix version**
  Changes in 0.30 and 0.31 do not break anything here.
  

- **debian: adjust rules for dh-cargo in forky**
  The comment about dh-cargo creating substvars file only for one package
  is still accurate. But the version in forky creates it for the other
  package... So, detect which one is missing and copy from the other one.
  
  QubesOS/qubes-issues#10930
  